### PR TITLE
Apply workspace and onboarding context providers to dashboard layout

### DIFF
--- a/projeto_alvo/src/app/dashboard/layout.tsx
+++ b/projeto_alvo/src/app/dashboard/layout.tsx
@@ -1,6 +1,21 @@
 import { AuthLayout } from '@/components/layout/auth-layout';
 import type { ReactNode } from 'react';
+import { WorkspaceProvider } from '@/contexts/WorkspaceContext';
+import { OnboardingTourProvider } from '@/contexts/OnboardingTourContext';
+
+function Providers({ children }: { children: ReactNode }) {
+  "use client";
+  return (
+    <WorkspaceProvider>
+      <OnboardingTourProvider>{children}</OnboardingTourProvider>
+    </WorkspaceProvider>
+  );
+}
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-  return <AuthLayout>{children}</AuthLayout>;
+  return (
+    <Providers>
+      <AuthLayout>{children}</AuthLayout>
+    </Providers>
+  );
 }

--- a/projeto_alvo/src/contexts/OnboardingTourContext.tsx
+++ b/projeto_alvo/src/contexts/OnboardingTourContext.tsx
@@ -1,4 +1,6 @@
 
+"use client";
+
 import { createContext, useContext, useState, useEffect } from "react";
 
 interface OnboardingTourContextType {

--- a/projeto_alvo/src/contexts/WorkspaceContext.tsx
+++ b/projeto_alvo/src/contexts/WorkspaceContext.tsx
@@ -1,4 +1,6 @@
 
+"use client";
+
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { LegalSubject } from '@/types/legalSubjects';
 


### PR DESCRIPTION
## Summary
- mark WorkspaceContext and OnboardingTourContext as client components
- wrap dashboard layout with WorkspaceProvider and OnboardingTourProvider

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854116f65bc832b98a59531e0eb7442